### PR TITLE
Publish docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.8
+      - image: golang
     working_directory: /go/src/github.com/raviqqe/liche
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,11 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang
+      - image: circleci/golang:1.8
     working_directory: /go/src/github.com/raviqqe/liche
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Setup
           command: |
@@ -32,3 +33,11 @@ jobs:
       - run:
           name: Install
           command: rake install
+
+#   publish-docker:
+#     docker:
+#       - image: docker:17.05.0-ce-git
+#     steps:
+#       - checkout
+#       - setup_remote_docker
+#       - run: docker build -t raviqqe/docker-liche:latest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,22 +36,19 @@ jobs:
           command: rake install
       - persist_to_workspace:
           root: .
-          paths: [ bin/liche, Dockerfile ]
+          paths: [ bin/liche, Dockerfile.test ]
 
-  publish-docker:
+  docker:
     docker:
       - image: docker:17.05.0-ce-git
     steps:
       - attach_workspace: { at: . }
       - setup_remote_docker
-      - run: docker build -t raviqqe/docker-liche:latest .
+      - run: docker build -f Dockerfile.test -t raviqqe/docker-liche:latest .
 
 workflows:
   version: 2
   build:
     jobs:
-      - build:
-          filters: { tags: { only: /.*/ } }
-      - publish-docker:
-          requires: [ build ]
-        #   filters: { tags: { only: /.*/ }, branches: { only: master } }
+      - build
+      - docker: { requires: [ build ] }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,14 +36,14 @@ jobs:
           command: rake install
       - persist_to_workspace:
           root: .
-          paths: [ bin/liche ]
+          paths: [ bin/liche, Dockerfile ]
 
   publish-docker:
     docker:
       - image: docker:17.05.0-ce-git
     steps:
+      - attach_workspace: { at: . }
       - setup_remote_docker
-      - attach_workspace: { at: /tmp }
       - run: docker build -t raviqqe/docker-liche:latest .
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,23 @@ jobs:
       - run:
           name: Install
           command: rake install
+      - persist_to_workspace:
+          root: .
+          paths: [ bin/liche ]
 
-#   publish-docker:
-#     docker:
-#       - image: docker:17.05.0-ce-git
-#     steps:
-#       - checkout
-#       - setup_remote_docker
-#       - run: docker build -t raviqqe/docker-liche:latest .
+  publish-docker:
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - setup_remote_docker
+      - attach_workspace: { at: /tmp }
+      - run: docker build -t raviqqe/docker-liche:latest .
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+      - publish-docker:
+          requires: [ build ]
+          filters: { tags: { only: /.*/ }, branches: { only: master } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2
 jobs:
+
   build:
     docker:
       - image: golang
@@ -49,7 +50,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - build:
+          filters: { tags: { only: /.*/ } }
       - publish-docker:
           requires: [ build ]
-          filters: { tags: { only: /.*/ }, branches: { only: master } }
+        #   filters: { tags: { only: /.*/ }, branches: { only: master } }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest
+
+RUN CGO_ENABLED=0 GOOS=linux go get -u github.com/raviqqe/liche
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/bin/liche /go/bin/liche
+ENV PATH "/go/bin:$PATH"
+CMD liche

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:latest
+FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-ADD /tmp/bin/liche /go/bin/liche
+ADD bin/liche /go/bin/liche
 # ENV PATH "/go/bin:$PATH"
 RUN liche --help
 CMD liche

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 ADD bin/liche /go/bin/liche
-# ENV PATH "/go/bin:$PATH"
+ENV PATH "/go/bin:$PATH"
 RUN liche --help
 CMD liche

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM golang:latest
-
-RUN CGO_ENABLED=0 GOOS=linux go get -u github.com/raviqqe/liche
-
-FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/bin/liche /go/bin/liche
-ENV PATH "/go/bin:$PATH"
+ADD /tmp/bin/liche /go/bin/liche
+# ENV PATH "/go/bin:$PATH"
+RUN liche --help
 CMD liche

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
+FROM golang:latest
+RUN CGO_ENABLED=0 GOOS=linux go get -u github.com/raviqqe/liche
+
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-ADD bin/liche /go/bin/liche
+COPY --from=0 /go/bin/liche /go/bin/liche
 ENV PATH "/go/bin:$PATH"
 RUN liche --help
 CMD liche

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,7 @@
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+ADD bin/liche /go/bin/liche
+ENV PATH "/go/bin:$PATH"
+RUN liche --help
+CMD liche

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -9,7 +9,7 @@ task :deps do
 end
 
 task :build do
-  sh 'go build -o bin/liche'
+  sh 'CGO_ENABLED=0 GOOS=linux go build -o bin/liche'
 end
 
 task :fast_unit_test do


### PR DESCRIPTION
## Motivation

I think this link checker is great and I'd like to use it as part of CI on a bunch of open-source repos I maintain.  We also use CircleCI, so it would be really convenient if there was a docker image available.

## After this PR

liche will seamlessly usable from within CircleCI: 

```yml
  markdown:
    docker:
      - image: raviqqe/liche:latest
    steps:
      - checkout
      - run: liche -d . -r . -v
```

## Implementation details

This PR ensures the `rake build` step produces a fully statically linked binary, and adds a 'docker' job to prove it works inside an alpine docker container.

If you're like to go ahead with this approach, you'd need to set up an account on [Docker hub](https://hub.docker.com/) and create a new Automated Build for this repository.

<img width="525" alt="screen shot 2018-11-19 at 14 46 39" src="https://user-images.githubusercontent.com/3473798/48714179-04410c00-ec0a-11e8-93f0-e2d011b08ae4.png">

Then, whenever you push to develop, docker hub will build the checked-in `Dockerfile` and make it available as `raviqqe/liche:latest`.

_I did a quick proof of concept here: https://github.com/iamdanfox/docker-liche, with the image available here: https://hub.docker.com/r/iamdanfox/docker-liche/. I'd much rather use a docker image built by the original repo, as my one will inevitably get out of date!_

