### PR TITLE
Windows Compatability

### DIFF
--- a/url_checker.go
+++ b/url_checker.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sync"
 	"time"
@@ -78,7 +79,7 @@ func (c urlChecker) resolveURL(u string, f string) (string, bool, error) {
 	}
 
 	if !path.IsAbs(uu.Path) {
-		return path.Join(path.Dir(f), uu.Path), true, nil
+		return path.Join(filepath.Dir(f), uu.Path), true, nil
 	}
 
 	if c.documentRoot == "" {


### PR DESCRIPTION
path module doesn't support windows paths

path.Dir('path\to\doc.md') returns "" instead of "path\to"
this causes a valid link to 'img.png' in this document to be reported as invalid, since later on we os.stat("img.png") when it should be os.stat("path\to\img.png")