### PR TITLE
Add hyperlink as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Sorry this project is not actively maintained anymore! 😢 Please consider migr
 - [lychee](https://github.com/lycheeverse/lychee)
   - A glorious link checker
   - This tool supports testing links both in local files and on websites.
+- [hyperlink](https://github.com/untitaker/hyperlink)
+  - Checks folder of HTML for relative/internal links (no markdown or external websites)
 
 ### Why is it not maintained anymore?
 


### PR DESCRIPTION
Sad to see liche go. I think hyperlink works very close to liche although it has a subset of features. Feel free to close if you think the README becomes too much of a billboard that way.

This is the second reference I have seen to different server behavior. I asked a follow-up question in a different bugtracker already https://github.com/filiph/linkcheck/issues/58 -- does the answer match your experience?